### PR TITLE
Add multi-language support for PR content generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This tool analyzes your local Git changes, uses AI (via OpenAI) to generate a re
 *   Analyzes committed changes between your current branch and a base branch (default: `main`).
 *   Generates PR title and body using AI (powered by Vercel AI SDK and OpenAI).
 *   Allows reviewing and editing the AI-generated content before creating the PR.
+*   Supports multiple languages for PR content generation.
 *   Checks for prerequisites (`git`, `gh` installed and authenticated, `OPENAI_API_KEY` set).
 *   Prompts to push the current branch if it doesn't exist on the remote.
 *   Optionally opens the created PR in your browser.
@@ -117,7 +118,8 @@ You can configure default options by creating a configuration file in your proje
 {
   "baseBranch": "develop",
   "model": "gpt-4.1-mini",
-  "skipConfirmations": false
+  "skipConfirmations": false,
+  "language": "portuguese"
 }
 ```
 
@@ -127,6 +129,7 @@ You can configure default options by creating a configuration file in your proje
 module.exports = {
   baseBranch: 'develop',
   model: 'gpt-4.1-mini',
+  language: 'spanish',
 };
 ```
 
@@ -141,12 +144,29 @@ Command-line arguments (e.g., `--base main`) will always override settings from 
     ```bash
     pr-magic
     ```
+5.  You can specify different options with command line arguments:
+    ```bash
+    # Generate PR content in Portuguese
+    pr-magic --language portuguese
+    
+    # Use a different model
+    pr-magic --model gpt-4o
+    
+    # Change base branch
+    pr-magic --base develop
+    
+    # Skip confirmations
+    pr-magic --yes
+    
+    # Combine multiple options
+    pr-magic --language spanish --model gpt-4o --base develop --yes
+    ```
 
  The tool will guide you through the process:
     *   Checking prerequisites.
     *   Analyzing commits against the base branch (`main` by default).
     *   Pushing the branch if needed (with confirmation).
-    *   Generating PR content with AI.
+    *   Generating PR content with AI in your specified language (English by default).
     *   Allowing you to review, edit, or confirm the content.
     *   Creating the PR on GitHub.
     *   Asking if you want to open the PR in the browser.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "pr-magic",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"description": "A command-line tool to automate GitHub Pull Request creation using AI",
 	"main": "dist/cli.js",
 	"bin": {

--- a/src/ai.ts
+++ b/src/ai.ts
@@ -26,13 +26,15 @@ export const PrContentSchema = z.object({
  * @param {string} diff - The git diff string.
  * @param {string} [commits] - The commit summaries string.
  * @param {string} [modelName='gpt-4.1-mini'] - The OpenAI model name to use.
+ * @param {string} [language='english'] - The language to generate the PR content in.
  * @returns {Promise<z.infer<typeof PrContentSchema>>} - The generated title and body.
  * @throws {Error} If API key is missing or AI generation fails.
  */
 export async function generatePrContent(
 	diff: string,
 	commits?: string,
-	modelName = "gpt-4.1-mini", // Add modelName parameter with default
+	modelName = "gpt-4.1-mini",
+	language = "english",
 ): Promise<z.infer<typeof PrContentSchema>> {
 	const spinner = ora(
 		theme.info("🤖 Generating PR content with AI..."),
@@ -44,15 +46,14 @@ export async function generatePrContent(
 			);
 		}
 
-		spinner.text = `🤖 Generating PR content using ${theme.info(modelName)}...`;
+		spinner.text = `🤖 Generating PR content using ${theme.info(modelName)} in ${theme.info(language)}...`;
 		const model = openai(modelName);
 
 		// System prompt providing context and instructions to the AI
-		const systemPrompt =
-			"You are an expert programmer assisting with drafting a GitHub Pull Request. Based on the provided git diff (representing changes since the base branch) and commit summaries, generate a concise, informative title (max 70 chars) and a detailed body description for the PR. The title should summarize the main changes reflected in the commits and diff. The body should explain the purpose and context of the changes, referencing the commit summaries if helpful. Use markdown formatting for the body.";
+		const systemPrompt = `You are an expert programmer assisting with drafting a GitHub Pull Request in ${language}. Based on the provided git diff (representing changes since the base branch) and commit summaries, generate a concise, informative title (max 70 chars) and a detailed body description for the PR. The title should summarize the main changes reflected in the commits and diff. The body should explain the purpose and context of the changes, referencing the commit summaries if helpful. Use markdown formatting for the body.`;
 
 		// User prompt providing the actual diff and commit data
-		const userPrompt = `Git Diff:\n\`\`\`diff\n${diff}\n\`\`\`\n\nCommit Summaries:\n\`\`\`\n${commits || "No commit summaries available."}\n\`\`\`\n\nPlease generate the PR title and body.`;
+		const userPrompt = `Git Diff:\n\`\`\`diff\n${diff}\n\`\`\`\n\nCommit Summaries:\n\`\`\`\n${commits || "No commit summaries available."}\n\`\`\`\n\nPlease generate the PR title and body in ${language}.`;
 
 		const { object } = await generateObject({
 			model,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -36,6 +36,11 @@ async function main() {
 			config.model,
 		) // Use config value as default
 		.option(
+			"-l, --language <language>",
+			"Specify the language for PR content (e.g., english, portuguese, spanish)",
+			config.language,
+		) // Use config value as default
+		.option(
 			"-y, --yes",
 			"Skip all confirmation prompts",
 			config.skipConfirmations,
@@ -49,6 +54,7 @@ async function main() {
 		...program.opts<{
 			base?: string;
 			model?: string;
+			language?: string;
 			yes?: boolean;
 			dryRun?: boolean;
 		}>(),
@@ -74,6 +80,7 @@ async function main() {
 			diff,
 			commits,
 			options.model,
+			options.language,
 		);
 
 		let finalPrContent: { title: string; body: string } | null = {

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,7 @@ const ConfigFileSchema = z
 		baseBranch: z.string().optional(),
 		model: z.string().optional(),
 		skipConfirmations: z.boolean().optional(), // Map to --yes flag
+		language: z.string().optional(), // Add language option
 	})
 	.strict(); // Use strict to prevent unknown properties
 
@@ -19,6 +20,7 @@ export const defaultConfig: Partial<AppConfig> = {
 	baseBranch: "main",
 	model: "gpt-4.1-mini",
 	skipConfirmations: false,
+	language: "english", // Default language is English
 };
 
 /**


### PR DESCRIPTION
This PR introduces support for generating Pull Request titles and descriptions in multiple languages using the AI model. Key changes include:

- Added a `language` option to the CLI, configuration file, and command line arguments, allowing users to specify the language for PR content (e.g., English, Portuguese, Spanish).
- Updated the AI prompt to instruct the model to generate content in the specified language.
- Enhanced the README with documentation on how to configure and use the new language option.
- Bumped the version to 1.0.2 to reflect the new feature.

This enhancement improves the tool's usability for non-English speakers and broadens its accessibility globally, making it easier to create PRs in the user's preferred language.