### PR TITLE
Rebrand CLI tool from pr-magic to gitmagic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PR Magic CLI 🧙✨
+# GitMagic CLI 🧙✨
 
 A command-line tool to automate GitHub Pull Request creation using AI.
 
@@ -27,33 +27,33 @@ This tool analyzes your local Git changes, uses AI (via OpenAI) to generate a re
 ### Via npm (Recommended)
 
 ```bash
-npm install -g pr-magic
+npm install -g gitmagic
 ```
 
 ### Via yarn
 
 ```bash
-yarn global add pr-magic
+yarn global add gitmagic
 ```
 
 ### Via pnpm
 
 ```bash
-pnpm add -g pr-magic
+pnpm add -g gitmagic
 ```
 
 ### Via bun
 
 ```bash
-bun add -g pr-magic
+bun add -g gitmagic
 ```
 
 ### From Source
 
 1.  **Clone the repository:**
     ```bash
-    git clone https://github.com/arthurbm/pr-magic.git
-    cd pr-magic
+    git clone https://github.com/arthurbm/gitmagic.git
+    cd gitmagic
     ```
 2.  **Install dependencies and build:**
     ```bash
@@ -87,7 +87,7 @@ bun add -g pr-magic
     # Using bun
     bun link
     ```
-    This makes the `pr-magic` command available in your terminal.
+    This makes the `gitmagic` command available in your terminal.
 
 ## Configuration
 
@@ -102,17 +102,17 @@ bun add -g pr-magic
 
 You can configure default options by creating a configuration file in your project directory or any parent directory. The tool uses `cosmiconfig` and will automatically look for:
 
-*   `.prmagicrc` (YAML or JSON)
-*   `.prmagicrc.json`
-*   `.prmagicrc.yaml`
-*   `.prmagicrc.yml`
-*   `.prmagicrc.js` (ESM or CJS)
-*   `.prmagicrc.cjs`
-*   `pr-magic.config.js` (ESM or CJS)
-*   `pr-magic.config.cjs`
-*   A `"pr-magic"` key in your `package.json`.
+*   `.gitmagicrc` (YAML or JSON)
+*   `.gitmagicrc.json`
+*   `.gitmagicrc.yaml`
+*   `.gitmagicrc.yml`
+*   `.gitmagicrc.js` (ESM or CJS)
+*   `.gitmagicrc.cjs`
+*   `gitmagic.config.js` (ESM or CJS)
+*   `gitmagic.config.cjs`
+*   A `"gitmagic"` key in your `package.json`.
 
-**Example `.prmagicrc.json**:**
+**Example `.gitmagicrc.json**:**
 
 ```json
 {
@@ -123,7 +123,7 @@ You can configure default options by creating a configuration file in your proje
 }
 ```
 
-**Example `.prmagicrc.js**:**
+**Example `.gitmagicrc.js**:**
 
 ```javascript
 module.exports = {
@@ -142,24 +142,24 @@ Command-line arguments (e.g., `--base main`) will always override settings from 
 3.  Ensure your desired changes are **committed** to the branch.
 4.  Run the command:
     ```bash
-    pr-magic
+    gitmagic
     ```
 5.  You can specify different options with command line arguments:
     ```bash
     # Generate PR content in Portuguese
-    pr-magic --language portuguese
+    gitmagic --language portuguese
     
     # Use a different model
-    pr-magic --model gpt-4o
+    gitmagic --model gpt-4o
     
     # Change base branch
-    pr-magic --base develop
+    gitmagic --base develop
     
     # Skip confirmations
-    pr-magic --yes
+    gitmagic --yes
     
     # Combine multiple options
-    pr-magic --language spanish --model gpt-4o --base develop --yes
+    gitmagic --language spanish --model gpt-4o --base develop --yes
     ```
 
  The tool will guide you through the process:
@@ -203,13 +203,13 @@ To remove the globally linked command:
 
 ```bash
 # Using npm
-npm unlink -g pr-magic
+npm unlink -g gitmagic
 
 # Using yarn
-yarn global remove pr-magic
+yarn global remove gitmagic
 
 # Using pnpm
-pnpm unlink -g pr-magic
+pnpm unlink -g gitmagic
 
 # Using bun
 bun unlink

--- a/bun.lock
+++ b/bun.lock
@@ -2,7 +2,7 @@
 	"lockfileVersion": 1,
 	"workspaces": {
 		"": {
-			"name": "pr-magic",
+			"name": "gitmagic",
 			"dependencies": {
 				"@ai-sdk/openai": "^1.3.19",
 				"ai": "^4.3.10",

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -1,6 +1,6 @@
 # PR AI CLI - Improvement Tracking
 
-List of suggestions to improve the `pr-magic` CLI, based on previous recommendations.
+List of suggestions to improve the `gitmagic` CLI, based on previous recommendations.
 
 ## 1. Argument Parsing and Configuration
 
@@ -9,7 +9,7 @@ List of suggestions to improve the `pr-magic` CLI, based on previous recommendat
   - [x] `--model <model-name>`: Choose OpenAI model.
   - [x] `-y` or `--yes`: Skip confirmations.
   - [x] `--dry-run`: See title/body without creating PR.
-- [x] **Configuration File:** Allow a file (`.pr-magic.json`?) to define defaults.
+- [x] **Configuration File:** Allow a file (`.gitmagic.json`?) to define defaults.
 
 ## 2. User Experience (UX) Improvements
 
@@ -48,4 +48,4 @@ List of suggestions to improve the `pr-magic` CLI, based on previous recommendat
 - [ ] **Authenticate with npm:** Run `npm login` (or `bunx npm login`).
 - [ ] **Versioning:** Use `npm version patch|minor|major` to update version before publishing.
 - [ ] **Publish:** Run `npm publish` (or `bunx npm publish`).
-- [ ] **Test Installation:** Install globally (`npm install -g pr-magic`) and test. 
+- [ ] **Test Installation:** Install globally (`npm install -g gitmagic`) and test. 

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-	"name": "pr-magic",
+	"name": "gitmagic",
 	"version": "1.0.3",
 	"description": "A command-line tool to automate GitHub Pull Request creation using AI",
 	"main": "dist/cli.js",
 	"bin": {
-		"pr-magic": "dist/cli.js"
+		"gitmagic": "dist/cli.js"
 	},
 	"type": "module",
 	"files": ["dist", "README.md", "LICENSE"],
@@ -27,12 +27,12 @@
 	],
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/arthurbm/pr-magic.git"
+		"url": "git+https://github.com/arthurbm/gitmagic.git"
 	},
 	"bugs": {
-		"url": "https://github.com/arthurbm/pr-magic/issues"
+		"url": "https://github.com/arthurbm/gitmagic/issues"
 	},
-	"homepage": "https://github.com/arthurbm/pr-magic#readme",
+	"homepage": "https://github.com/arthurbm/gitmagic#readme",
 	"devDependencies": {
 		"@biomejs/biome": "1.9.4",
 		"@types/bun": "latest"

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,7 +30,7 @@ export const defaultConfig: Partial<AppConfig> = {
  * @returns {Promise<Required<AppConfig>>} The loaded and merged configuration (ensuring all fields are present).
  */
 export async function loadConfig(): Promise<Required<AppConfig>> {
-	const explorer = cosmiconfig("pr-magic"); // Module name for searching
+	const explorer = cosmiconfig("gitmagic"); // Module name for searching
 	let loadedConfig: AppConfig = {};
 
 	try {


### PR DESCRIPTION
This PR updates the entire project to reflect the new branding from `pr-magic` to `gitmagic`. The changes include:

- Renaming the CLI command from `pr-magic` to `gitmagic` in documentation, installation instructions, and usage examples.
- Updating package metadata such as `name`, `bin` command, repository URLs, issue tracker URLs, and homepage URLs in `package.json`.
- Changing configuration file names and keys from `.prmagicrc` and `pr-magic` to `.gitmagicrc` and `gitmagic` respectively.
- Modifying the cosmiconfig module name used for configuration loading from `pr-magic` to `gitmagic`.
- Updating the project name in the lock file and documentation.

These changes ensure consistent branding across the project and its documentation, installation, and configuration processes.