### PR TITLE
refactor: add 'generate pr' subcommand for PR generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,24 +142,24 @@ Command-line arguments (e.g., `--base main`) will always override settings from 
 3.  Ensure your desired changes are **committed** to the branch.
 4.  Run the command:
     ```bash
-    gitmagic
+    gitmagic generate pr
     ```
 5.  You can specify different options with command line arguments:
     ```bash
     # Generate PR content in Portuguese
-    gitmagic --language portuguese
+    gitmagic generate pr --language portuguese
     
     # Use a different model
-    gitmagic --model gpt-4o
+    gitmagic generate pr --model gpt-4o
     
     # Change base branch
-    gitmagic --base develop
+    gitmagic generate pr --base develop
     
     # Skip confirmations
-    gitmagic --yes
+    gitmagic generate pr --yes
     
     # Combine multiple options
-    gitmagic --language spanish --model gpt-4o --base develop --yes
+    gitmagic generate pr --language spanish --model gpt-4o --base develop --yes
     ```
 
  The tool will guide you through the process:

--- a/docs/plan.md
+++ b/docs/plan.md
@@ -48,4 +48,27 @@ List of suggestions to improve the `gitmagic` CLI, based on previous recommendat
 - [ ] **Authenticate with npm:** Run `npm login` (or `bunx npm login`).
 - [ ] **Versioning:** Use `npm version patch|minor|major` to update version before publishing.
 - [ ] **Publish:** Run `npm publish` (or `bunx npm publish`).
-- [ ] **Test Installation:** Install globally (`npm install -g gitmagic`) and test. 
+- [ ] **Test Installation:** Install globally (`npm install -g gitmagic`) and test.
+
+## 7. Command Structure Refactoring
+
+- [x] **Initial Subcommand Architecture:**
+  - [x] Refactor current PR generation into `gitmagic generate pr`
+  - [x] Create command factory infrastructure
+  - [x] Update documentation to reflect new command structure
+
+- [ ] **Future Command Extensions:**
+  - [ ] `gitmagic generate commit` - AI-powered commit message generation
+  - [ ] `gitmagic review <pr_url>` - AI-assisted PR review
+  - [ ] Additional commands as needed
+
+## 8. Configuration and Setup
+
+- [ ] **Init Command:** Implement `npx gitmagic init` to:
+  - [ ] Create default configuration file
+  - [ ] Guide user through setting up API keys and preferences
+  - [ ] Set up additional customizations
+- [ ] **Custom Rules:** Support user-defined rules in configuration file
+  - [ ] PR templates/rules
+  - [ ] Commit message templates/rules
+  - [ ] Review criteria/rules 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,127 +2,39 @@
 
 import { program } from "commander"; // Import commander
 import { version } from "../package.json"; // Import version for CLI
-import { generatePrContent } from "./ai";
+import { registerGenerateCommands } from "./commands/generate";
 import { loadConfig } from "./config"; // Import config loader
-import { ensureBranchIsPushed, getGitInfo } from "./git";
-import { askAndOpenPr, createGitHubPr } from "./github";
-import { checkPrerequisites } from "./prerequisites";
 import { theme } from "./theme";
-import { reviewAndConfirmPr } from "./ui";
 
 /**
  * Main function for the PR AI CLI.
  * Orchestrates the process of checking prerequisites, getting git info,
  * generating AI content, reviewing, creating the PR, and opening it.
  */
-async function main() {
+async function mainCli() {
 	console.log(theme.primary("🚀 Starting PR AI CLI..."));
 
-	// Load configuration from file first
-	const config = await loadConfig();
-
-	// --- Argument Parsing (using loaded config as defaults) ---
-	program
-		.version(version)
-		.description("Automate GitHub Pull Request creation using AI.")
-		.option(
-			"-b, --base <branch>",
-			"Specify the base branch for comparison",
-			config.baseBranch,
-		) // Use config value as default
-		.option(
-			"-m, --model <model-name>",
-			"Specify the OpenAI model to use",
-			config.model,
-		) // Use config value as default
-		.option(
-			"-l, --language <language>",
-			"Specify the language for PR content (e.g., english, portuguese, spanish)",
-			config.language,
-		) // Use config value as default
-		.option(
-			"-y, --yes",
-			"Skip all confirmation prompts",
-			config.skipConfirmations,
-		) // Use config value as default
-		.option("--dry-run", "Generate title/body but do not create PR", false)
-		.parse(process.argv);
-
-	// Get the final options (CLI args override config/defaults)
-	const options = {
-		...config,
-		...program.opts<{
-			base?: string;
-			model?: string;
-			language?: string;
-			yes?: boolean;
-			dryRun?: boolean;
-		}>(),
-	};
-	// Ensure boolean flags from commander don't override config `false` with `undefined` if not passed
-	options.yes = program.opts().yes ?? config.skipConfirmations ?? false;
-	options.dryRun = program.opts().dryRun ?? false;
-
-	if (options.dryRun) {
-		console.log(
-			theme.warning("Running in dry-run mode. No PR will be created."),
-		);
-	}
-
 	try {
-		await checkPrerequisites();
-		const { currentBranch, diff, commits } = await getGitInfo(
-			options.base,
-			options.yes,
-		);
-		await ensureBranchIsPushed(currentBranch, options.yes);
-		const { title: initialTitle, body: initialBody } = await generatePrContent(
-			diff,
-			commits,
-			options.model,
-			options.language,
-		);
+		const config = await loadConfig();
 
-		let finalPrContent: { title: string; body: string } | null = {
-			title: initialTitle,
-			body: initialBody,
-		};
+		program.version(version).description("GitMagic: AI-powered Git utilities.");
 
-		if (!options.yes) {
-			// Skip review if --yes is passed
-			finalPrContent = await reviewAndConfirmPr(initialTitle, initialBody);
-		}
+		registerGenerateCommands(program, config);
 
-		if (!finalPrContent) {
-			process.exit(0); // User cancelled during review
-		}
-
-		const { title, body } = finalPrContent;
-
-		if (options.dryRun) {
-			console.log(`\n${theme.primary("Dry Run Results:")}`);
-			console.log(`${theme.info("Title:")} ${title}`);
-			console.log(`${theme.info("Body:\n")}${theme.dim(body)}`);
-			console.log(
-				theme.warning("\nExiting due to --dry-run flag. No PR created."),
-			);
-			process.exit(0);
-		}
-
-		const prUrl = await createGitHubPr(title, body);
-		await askAndOpenPr(prUrl, options.yes);
-
-		console.log(theme.success("\n✨ PR AI process finished successfully!"));
+		await program.parseAsync(process.argv);
 	} catch (error: unknown) {
 		// Specific errors should be handled and logged within modules
 		// This logs the final error message before exiting
 		if (error instanceof Error) {
-			console.error(theme.error(`\n❌ Error: ${error.message}`));
+			console.error(theme.error(`\n❌ CLI Error: ${error.message}`));
 		} else {
-			console.error(theme.error("\n❌ An unexpected error occurred:"), error);
+			console.error(
+				theme.error("\n❌ An unexpected CLI error occurred:"),
+				error,
+			);
 		}
 		process.exit(1);
 	}
 }
 
-main();
+mainCli();

--- a/src/commands/generate/index.ts
+++ b/src/commands/generate/index.ts
@@ -1,0 +1,18 @@
+import type { Command } from "commander";
+import type { AppConfig } from "../../config";
+import { registerPrCommand } from "./pr";
+
+export function registerGenerateCommands(
+	program: Command,
+	config: Required<AppConfig>,
+) {
+	const generateCommand = program
+		.command("generate")
+		.description(
+			"Generate various artifacts (e.g., PR descriptions, commit messages).",
+		);
+
+	// Register subcommands for 'generate'
+	registerPrCommand(generateCommand, config);
+	// Future commands like registerCommitCommand(generateCommand, config) can be added here.
+}

--- a/src/commands/generate/pr.ts
+++ b/src/commands/generate/pr.ts
@@ -1,0 +1,118 @@
+import type { Command } from "commander";
+import { generatePrContent } from "../../ai";
+import type { AppConfig } from "../../config"; // Using AppConfig and Required
+import { ensureBranchIsPushed, getGitInfo } from "../../git";
+import { askAndOpenPr, createGitHubPr } from "../../github";
+import { checkPrerequisites } from "../../prerequisites";
+import { theme } from "../../theme";
+import { reviewAndConfirmPr } from "../../ui";
+
+// Define the expected shape of options for this command
+interface GeneratePrOptions {
+	base: string;
+	model: string;
+	language: string;
+	yes: boolean;
+	dryRun: boolean;
+}
+
+async function handleGeneratePr(options: GeneratePrOptions) {
+	console.log(theme.primary("🚀 Starting GitMagic PR Generation..."));
+
+	if (options.dryRun) {
+		console.log(
+			theme.warning("Running in dry-run mode. No PR will be created."),
+		);
+	}
+
+	try {
+		await checkPrerequisites();
+		const { currentBranch, diff, commits } = await getGitInfo(
+			options.base,
+			options.yes,
+		);
+		await ensureBranchIsPushed(currentBranch, options.yes);
+		const { title: initialTitle, body: initialBody } = await generatePrContent(
+			diff,
+			commits,
+			options.model,
+			options.language,
+		);
+
+		let finalPrContent: { title: string; body: string } | null = {
+			title: initialTitle,
+			body: initialBody,
+		};
+
+		if (!options.yes) {
+			finalPrContent = await reviewAndConfirmPr(initialTitle, initialBody);
+		}
+
+		if (!finalPrContent) {
+			console.log(theme.warning("PR generation cancelled."));
+			process.exit(0);
+		}
+
+		const { title, body } = finalPrContent;
+
+		if (options.dryRun) {
+			console.log(`\\n${theme.primary("Dry Run Results:")}`);
+			console.log(`${theme.info("Title:")} ${title}`);
+			console.log(`${theme.info("Body:\\n")}${theme.dim(body)}`);
+			console.log(
+				theme.warning("\\nExiting due to --dry-run flag. No PR created."),
+			);
+			process.exit(0);
+		}
+
+		const prUrl = await createGitHubPr(title, body);
+		await askAndOpenPr(prUrl, options.yes);
+
+		console.log(theme.success("\\n✨ PR AI process finished successfully!"));
+	} catch (error: unknown) {
+		if (error instanceof Error) {
+			console.error(
+				theme.error(`\\n❌ Error in PR Generation: ${error.message}`),
+			);
+		} else {
+			console.error(
+				theme.error("\\n❌ An unexpected error occurred during PR Generation:"),
+				error,
+			);
+		}
+		process.exit(1);
+	}
+}
+
+export function registerPrCommand(
+	generateCommand: Command,
+	config: Required<AppConfig>,
+) {
+	generateCommand
+		.command("pr")
+		.description("Generate a Pull Request description and title using AI.")
+		.option(
+			"-b, --base <branch>",
+			"Specify the base branch for comparison",
+			config.baseBranch,
+		)
+		.option(
+			"-m, --model <model-name>",
+			"Specify the OpenAI model to use",
+			config.model,
+		)
+		.option(
+			"-l, --language <language>",
+			"Specify the language for PR content (e.g., english, portuguese, spanish)",
+			config.language,
+		)
+		.option(
+			"-y, --yes",
+			"Skip all confirmation prompts",
+			config.skipConfirmations,
+		)
+		.option("--dry-run", "Generate title/body but do not create PR", false)
+		.action(async (cmdOptions: GeneratePrOptions) => {
+			await handleGeneratePr(cmdOptions);
+		});
+}


### PR DESCRIPTION
This PR refactors the CLI command structure by introducing a new subcommand architecture under `gitmagic generate pr` for generating pull request content using AI.

### Changes:
- Added a `generate` command group with a `pr` subcommand to handle PR generation.
- Moved the PR generation logic from the main CLI entry point into the new `generate pr` command handler.
- Updated CLI usage examples in README to reflect the new command structure.
- Simplified the main CLI file to register commands and delegate functionality.
- Added detailed options for `generate pr` including base branch, model, language, confirmation skipping, and dry-run.
- Updated documentation plan to include this new command structure and future extensibility.

### Benefits:
- Clearer and more extensible CLI command hierarchy.
- Easier to add new AI-powered commands like commit message generation or PR review in the future.
- Improved user experience with consistent command usage patterns.

This refactor lays the groundwork for expanding GitMagic's AI-powered git utilities beyond just PR generation.